### PR TITLE
Fix link for https://opencitations.net/meta

### DIFF
--- a/data/data.json
+++ b/data/data.json
@@ -713,7 +713,7 @@
   {
     "id": "48",
     "name": "Open Citations Meta",
-    "link": "https:\/\/opencitations.net\/meta\/",
+    "link": "https:\/\/opencitations.net\/meta",
     "image_url": "https:\/\/opencitations.net\/static\/img\/logo.png",
     "description": "The OpenCitations Meta database stores and delivers bibliographic metadata for all publications involved in the OpenCitations Indexes",
     "category": "Data aggregator",


### PR DESCRIPTION
https://opencitations.net/meta works, https://opencitations.net/meta/ does not. 

Closes https://github.com/TIBHannover/rosi-registry/issues/27. 